### PR TITLE
feat:remove padding & add custom serialization

### DIFF
--- a/qubic.go
+++ b/qubic.go
@@ -645,75 +645,10 @@ func serializeBinary(data interface{}) ([]byte, error) {
 		return nil, nil
 	}
 
-	// Handle RequestAssetsByFilter specially to omit unnecessary fields for issuance requests
-	if filterReq, ok := data.(RequestAssetsByFilter); ok {
-		return serializeRequestAssetsByFilter(filterReq)
-	}
-
 	var buff bytes.Buffer
 	err := binary.Write(&buff, binary.LittleEndian, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "writing data to buff")
-	}
-
-	return buff.Bytes(), nil
-}
-
-func serializeRequestAssetsByFilter(req RequestAssetsByFilter) ([]byte, error) {
-	var buff bytes.Buffer
-
-	// Write RequestType
-	err := binary.Write(&buff, binary.LittleEndian, req.RequestType)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing RequestType")
-	}
-
-	// Write Flags
-	err = binary.Write(&buff, binary.LittleEndian, req.Flags)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing Flags")
-	}
-
-	// Write OwnershipManagingContract
-	err = binary.Write(&buff, binary.LittleEndian, req.OwnershipManagingContract)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing OwnershipManagingContract")
-	}
-
-	// Write PossessionManagingContract
-	err = binary.Write(&buff, binary.LittleEndian, req.PossessionManagingContract)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing PossessionManagingContract")
-	}
-
-	// Write Issuer
-	err = binary.Write(&buff, binary.LittleEndian, req.Issuer)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing Issuer")
-	}
-
-	// Write AssetName
-	err = binary.Write(&buff, binary.LittleEndian, req.AssetName)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing AssetName")
-	}
-
-	// For issuance requests (type 0), don't send Owner and Possessor fields
-	// For ownership/possession requests, include them
-	if req.RequestType == requestTypeAssetIssuanceRecords {
-		// Only send up to AssetName (48 bytes total)
-		return buff.Bytes(), nil
-	}
-
-	// For ownership and possession requests, include Owner and Possessor
-	err = binary.Write(&buff, binary.LittleEndian, req.Owner)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing Owner")
-	}
-
-	err = binary.Write(&buff, binary.LittleEndian, req.Possessor)
-	if err != nil {
-		return nil, errors.Wrap(err, "writing Possessor")
 	}
 
 	return buff.Bytes(), nil

--- a/qubic_test.go
+++ b/qubic_test.go
@@ -31,13 +31,8 @@ func TestQubic_serializeBinary_requestIssuedAssetsByFilter_thenProduceCorrectBin
 	bytes, err := serializeBinary(request)
 	assert.NoError(t, err)
 
-	// For issuance requests, only send up to AssetName (48 bytes), without Owner/Possessor
-	// RequestType (2B) + Flags (2B) + OwnershipManagingContract (2B) + PossessionManagingContract (2B) + Issuer (32B) + AssetName (8B) = 48 bytes
 	expectedHex := "00000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	// Remove the Owner and Possessor fields (64 bytes) from the end
-	expectedHex = expectedHex[:96] // 48 bytes = 96 hex chars
 	assert.Equal(t, expectedHex, hex.EncodeToString(bytes))
-	assert.Equal(t, 48, len(bytes))
 }
 
 func TestQubic_serializeBinary_requestIssuedAssetsByFilter_givenIssuer_thenProduceCorrectBinary(t *testing.T) {
@@ -48,11 +43,8 @@ func TestQubic_serializeBinary_requestIssuedAssetsByFilter_givenIssuer_thenProdu
 	bytes, err := serializeBinary(request)
 	assert.NoError(t, err)
 
-	// For issuance requests, only send up to AssetName (48 bytes), without Owner/Possessor
 	expectedHex := "00000400000000000830bb63bf7d5e164ac8cbd38680630ff7670a1ebf39f7210b40bcdca253d05f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	expectedHex = expectedHex[:96] // Remove Owner and Possessor (64 bytes = 128 hex chars)
 	assert.Equal(t, expectedHex, hex.EncodeToString(bytes))
-	assert.Equal(t, 48, len(bytes))
 }
 
 func TestQubic_serializeBinary_requestIssuedAssetsByFilter_givenAssetName_thenProduceCorrectBinary(t *testing.T) {
@@ -63,11 +55,8 @@ func TestQubic_serializeBinary_requestIssuedAssetsByFilter_givenAssetName_thenPr
 	bytes, err := serializeBinary(request)
 	assert.NoError(t, err)
 
-	// For issuance requests, only send up to AssetName (48 bytes), without Owner/Possessor
 	expectedHex := "0000020000000000000000000000000000000000000000000000000000000000000000000000000052414e444f4d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	expectedHex = expectedHex[:96] // Remove Owner and Possessor (64 bytes = 128 hex chars)
 	assert.Equal(t, expectedHex, hex.EncodeToString(bytes))
-	assert.Equal(t, 48, len(bytes))
 }
 
 func TestQubic_serializeBinary_requestIssuedAssetsByFilter_givenIssuerAndAssetName_thenProduceCorrectBinary(t *testing.T) {
@@ -78,11 +67,8 @@ func TestQubic_serializeBinary_requestIssuedAssetsByFilter_givenIssuerAndAssetNa
 	bytes, err := serializeBinary(request)
 	assert.NoError(t, err)
 
-	// For issuance requests, only send up to AssetName (48 bytes), without Owner/Possessor
 	expectedHex := "00000000000000000830bb63bf7d5e164ac8cbd38680630ff7670a1ebf39f7210b40bcdca253d05f434642000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	expectedHex = expectedHex[:96] // Remove Owner and Possessor (64 bytes = 128 hex chars)
 	assert.Equal(t, expectedHex, hex.EncodeToString(bytes))
-	assert.Equal(t, 48, len(bytes))
 }
 
 func TestQubic_serializeBinary_requestOwnedAssetsByFilter_thenProduceCorrectBinary(t *testing.T) {


### PR DESCRIPTION
1. Removed padding from RequestAssetsByUniverseIndex
- Removed 104-byte padding field
- Reduced message size from 112 bytes to 8 bytes (93% reduction)
- Only sends required fields: RequestType, Flags, UniverseIndex

2. Custom serialization for RequestAssetsByFilter
- Added serializeRequestAssetsByFilter() for conditional serialization
- Issuance requests (type 0) exclude Owner and Possessor fields
- Reduced issuance request size from 112 bytes to 48 bytes (57% reduction)
- Ownership/possession requests remain 112 bytes (unchanged)

Closes #22 