### PR TITLE
Add Must variants and named Identity constructors

### DIFF
--- a/types/identity.go
+++ b/types/identity.go
@@ -93,6 +93,36 @@ func (i *Identity) ToPubKey(isLowerCase bool) ([32]byte, error) {
 	return pubKey, nil
 }
 
+// NewTxID creates a transaction-ID Identity (lowercase) from a 32-byte digest.
+func NewTxID(digest [32]byte) (Identity, error) {
+	var id Identity
+	return id.FromPubKey(digest, true)
+}
+
+// NewAddress creates an address Identity (uppercase) from a 32-byte public key.
+func NewAddress(pubKey [32]byte) (Identity, error) {
+	var id Identity
+	return id.FromPubKey(pubKey, false)
+}
+
+// MustNewTxID is like NewTxID but panics on error.
+func MustNewTxID(digest [32]byte) Identity {
+	id, err := NewTxID(digest)
+	if err != nil {
+		panic(fmt.Errorf("creating tx id: %w", err))
+	}
+	return id
+}
+
+// MustNewAddress is like NewAddress but panics on error.
+func MustNewAddress(pubKey [32]byte) Identity {
+	id, err := NewAddress(pubKey)
+	if err != nil {
+		panic(fmt.Errorf("creating address: %w", err))
+	}
+	return id
+}
+
 func (i *Identity) String() string {
 	if i == nil {
 		return ""

--- a/types/identity_test.go
+++ b/types/identity_test.go
@@ -39,6 +39,64 @@ func TestGetIdentityFromPubkeyLowerCase(t *testing.T) {
 	}
 }
 
+func TestNewAddress_MatchesFromPubKeyUppercase(t *testing.T) {
+	pubKey := [32]byte{230, 252, 58, 173, 75, 89, 77, 130, 191, 49, 3, 161, 16, 22, 216, 13, 232, 131, 222, 135, 59, 206, 196, 142, 144, 57, 98, 134, 80, 59, 38, 19}
+	expectedIdentity := "QJRRSSKMJRDKUDTYVNYGAMQPULKAMILQQYOWBEXUDEUWQUMNGDHQYLOAJMEB"
+
+	got, err := NewAddress(pubKey)
+	if err != nil {
+		t.Fatalf("NewAddress returned err: %s", err.Error())
+	}
+
+	if cmp.Diff(string(got), expectedIdentity) != "" {
+		t.Fatalf("Mismatched return value. Expected: %s, got: %s", expectedIdentity, got)
+	}
+}
+
+func TestNewTxID_MatchesFromPubKeyLowercase(t *testing.T) {
+	digest := [32]byte{230, 252, 58, 173, 75, 89, 77, 130, 191, 49, 3, 161, 16, 22, 216, 13, 232, 131, 222, 135, 59, 206, 196, 142, 144, 57, 98, 134, 80, 59, 38, 19}
+	expectedIdentity := strings.ToLower("QJRRSSKMJRDKUDTYVNYGAMQPULKAMILQQYOWBEXUDEUWQUMNGDHQYLOAJMEB")
+
+	got, err := NewTxID(digest)
+	if err != nil {
+		t.Fatalf("NewTxID returned err: %s", err.Error())
+	}
+
+	if cmp.Diff(string(got), expectedIdentity) != "" {
+		t.Fatalf("Mismatched return value. Expected: %s, got: %s", expectedIdentity, got)
+	}
+}
+
+func TestMustNewAddress_MatchesNewAddress(t *testing.T) {
+	pubKey := [32]byte{230, 252, 58, 173, 75, 89, 77, 130, 191, 49, 3, 161, 16, 22, 216, 13, 232, 131, 222, 135, 59, 206, 196, 142, 144, 57, 98, 134, 80, 59, 38, 19}
+
+	want, err := NewAddress(pubKey)
+	if err != nil {
+		t.Fatalf("NewAddress returned err: %s", err.Error())
+	}
+
+	got := MustNewAddress(pubKey)
+
+	if cmp.Diff(string(got), string(want)) != "" {
+		t.Fatalf("Mismatched return value. Expected: %s, got: %s", want, got)
+	}
+}
+
+func TestMustNewTxID_MatchesNewTxID(t *testing.T) {
+	digest := [32]byte{230, 252, 58, 173, 75, 89, 77, 130, 191, 49, 3, 161, 16, 22, 216, 13, 232, 131, 222, 135, 59, 206, 196, 142, 144, 57, 98, 134, 80, 59, 38, 19}
+
+	want, err := NewTxID(digest)
+	if err != nil {
+		t.Fatalf("NewTxID returned err: %s", err.Error())
+	}
+
+	got := MustNewTxID(digest)
+
+	if cmp.Diff(string(got), string(want)) != "" {
+		t.Fatalf("Mismatched return value. Expected: %s, got: %s", want, got)
+	}
+}
+
 func TestGetPubKeyFromIdentityUppercase(t *testing.T) {
 	identity := "QJRRSSKMJRDKUDTYVNYGAMQPULKAMILQQYOWBEXUDEUWQUMNGDHQYLOAJMEB"
 	expectedPubKey := [32]byte{230, 252, 58, 173, 75, 89, 77, 130, 191, 49, 3, 161, 16, 22, 216, 13, 232, 131, 222, 135, 59, 206, 196, 142, 144, 57, 98, 134, 80, 59, 38, 19}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -146,8 +146,7 @@ func (tx *Transaction) ID() (string, error) {
 		return "", fmt.Errorf("getting digest: %w", err)
 	}
 
-	var id Identity
-	id, err = id.FromPubKey(digest, true)
+	id, err := NewTxID(digest)
 	if err != nil {
 		return "", fmt.Errorf("getting id from pubkey: %w", err)
 	}
@@ -164,14 +163,7 @@ func (tx *Transaction) MustDigest() [32]byte {
 }
 
 func (tx *Transaction) MustID() string {
-	digest := tx.MustDigest()
-
-	var id Identity
-	id, err := id.FromPubKey(digest, true)
-	if err != nil {
-		panic(fmt.Errorf("getting id from pubkey: %w", err))
-	}
-
+	id := MustNewTxID(tx.MustDigest())
 	return id.String()
 }
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -155,6 +155,26 @@ func (tx *Transaction) ID() (string, error) {
 	return id.String(), nil
 }
 
+func (tx *Transaction) MustDigest() [32]byte {
+	digest, err := tx.Digest()
+	if err != nil {
+		panic(fmt.Errorf("getting digest: %w", err))
+	}
+	return digest
+}
+
+func (tx *Transaction) MustID() string {
+	digest := tx.MustDigest()
+
+	var id Identity
+	id, err := id.FromPubKey(digest, true)
+	if err != nil {
+		panic(fmt.Errorf("getting id from pubkey: %w", err))
+	}
+
+	return id.String()
+}
+
 func (tx *Transaction) EncodeToBase64() (string, error) {
 	txPacket, err := tx.MarshallBinary()
 	if err != nil {

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -35,6 +35,44 @@ func TestTransaction_MarshallUnmarshall(t *testing.T) {
 	}
 }
 
+func TestTransaction_MustDigest_MatchesDigest(t *testing.T) {
+	tx := Transaction{
+		SourcePublicKey:      [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		DestinationPublicKey: [32]byte{11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+		Amount:               100,
+		Tick:                 200,
+		InputType:            300,
+		InputSize:            10,
+		Input:                []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		Signature:            [64]byte{21, 22, 23, 24, 25, 26, 27, 28, 29, 30},
+	}
+
+	want, err := tx.Digest()
+	require.NoError(t, err, "computing digest")
+
+	got := tx.MustDigest()
+	require.Equal(t, want, got, "MustDigest should match Digest")
+}
+
+func TestTransaction_MustID_MatchesID(t *testing.T) {
+	tx := Transaction{
+		SourcePublicKey:      [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		DestinationPublicKey: [32]byte{11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+		Amount:               100,
+		Tick:                 200,
+		InputType:            300,
+		InputSize:            10,
+		Input:                []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		Signature:            [64]byte{21, 22, 23, 24, 25, 26, 27, 28, 29, 30},
+	}
+
+	want, err := tx.ID()
+	require.NoError(t, err, "computing ID")
+
+	got := tx.MustID()
+	require.Equal(t, want, got, "MustID should match ID")
+}
+
 func TestSendManyTransferPayload_Size(t *testing.T) {
 	var payload SendManyTransferPayload
 	b, err := payload.MarshallBinary()


### PR DESCRIPTION
## Summary

- Add `Transaction.MustDigest()` and `Transaction.MustID()` — panic-on-error variants of `Digest` / `ID` for callers that hold a well-formed transaction.
- Add package-level `NewTxID(digest)` / `NewAddress(pubKey)` constructors and their `MustNewTxID` / `MustNewAddress` variants. These wrap `Identity.FromPubKey` and replace the semantic boolean (`isLowerCase=true` → tx ID, `false` → address) with named intent at call sites.
- Refactor `Transaction.ID` / `MustID` to delegate to the new helpers.

Existing `Identity.FromPubKey` / `ToPubKey` remain for back-compat; this PR is additive.

## Test plan

- [x] `go test ./types/...` — all tests pass (including new TDD-first tests: `TestTransaction_MustDigest_MatchesDigest`, `TestTransaction_MustID_MatchesID`, `TestNewAddress_MatchesFromPubKeyUppercase`, `TestNewTxID_MatchesFromPubKeyLowercase`, `TestMustNewAddress_MatchesNewAddress`, `TestMustNewTxID_MatchesNewTxID`)
- [x] `go vet ./types/...` clean
- [x] `go build ./types/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)